### PR TITLE
CCM-17397: Update mesh-poll Timeout Buffer

### DIFF
--- a/infrastructure/terraform/components/dl/module_lambda_mesh_poll.tf
+++ b/infrastructure/terraform/components/dl/module_lambda_mesh_poll.tf
@@ -42,7 +42,7 @@ module "mesh_poll" {
     ENVIRONMENT                         = var.environment
     EVENT_PUBLISHER_DLQ_URL             = module.sqs_event_publisher_errors.sqs_queue_url
     EVENT_PUBLISHER_EVENT_BUS_ARN       = aws_cloudwatch_event_bus.main.arn
-    MAXIMUM_RUNTIME_MILLISECONDS        = "240000" # 4 minutes (Lambda has 5 min timeout)
+    LAMBDA_TIMEOUT_BUFFER_MILLISECONDS  = "60000" # 1 minute, to leave time for mesh-download to acknowledge the message before we run again.
     POLLING_METRIC_NAME                 = "mesh-poll-successful-polls"
     POLLING_METRIC_NAMESPACE            = "dl-mesh-poll"
     SSM_MESH_PREFIX                     = local.ssm_mesh_prefix

--- a/lambdas/mesh-poll/mesh_poll/__tests__/test_processor.py
+++ b/lambdas/mesh-poll/mesh_poll/__tests__/test_processor.py
@@ -13,7 +13,7 @@ def setup_mocks():
     Create all mock objects needed for processor testing
     """
     config = Mock()
-    config.maximum_runtime_milliseconds = "500"
+    config.lambda_timeout_buffer_milliseconds = "500"
     config.ssm_prefix = "/dl/test"
     config.environment = "development"
 

--- a/lambdas/mesh-poll/mesh_poll/config.py
+++ b/lambdas/mesh-poll/mesh_poll/config.py
@@ -8,7 +8,7 @@ __all__ = ['Config', 'log']
 _REQUIRED_ENV_VAR_MAP = {
     "ssm_senders_prefix": "SSM_SENDERS_PREFIX",
     "ssm_mesh_prefix": "SSM_MESH_PREFIX",
-    "maximum_runtime_milliseconds": "MAXIMUM_RUNTIME_MILLISECONDS",
+    "lambda_timeout_buffer_milliseconds": "LAMBDA_TIMEOUT_BUFFER_MILLISECONDS",
     "environment": "ENVIRONMENT",
     "event_bus_arn": "EVENT_PUBLISHER_EVENT_BUS_ARN",
     "event_publisher_dlq_url": "EVENT_PUBLISHER_DLQ_URL",

--- a/lambdas/mesh-poll/mesh_poll/processor.py
+++ b/lambdas/mesh-poll/mesh_poll/processor.py
@@ -44,11 +44,11 @@ class MeshMessageProcessor:  # pylint: disable=too-many-instance-attributes
 
     def is_enough_time_to_process_message(self):
         """
-        Determines whether the lambda should continue to process messages
+        Determines whether the lambda should continue to process messages.
         """
         remaining_time_in_millis = self.__get_remaining_time_in_millis()
 
-        return int(self.__config.maximum_runtime_milliseconds) \
+        return int(self.__config.lambda_timeout_buffer_milliseconds) \
             < remaining_time_in_millis
 
     def process_messages(self):


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR updates the mesh-poll lambda's `MAXIMUM_RUNTIME_MILLISECONDS` environment variable so it is now called `LAMBDA_TIMEOUT_BUFFER_MILLISECONDS` and sets the value to `60000` (it was originally `240000`).

## Context

The original variable name was confusing, as it reads like it represents the maximum total time the lambda will run for, but it is actually used as a value to compare the remaining time the lambda has to run against and if there is less time left to run no more messages are processes (see `processor.py`).

The current value appears to have been set based on the erroneous expectation that it represents the total time the lambda runs for (it's set to 4 minutes), but we saw from the recent performance test that it is actually resulting in the lambda running for only 1 minute (the timeout of 5 mins - 4 mins) before declaring it doesn't have enough time left to process messages and then sitting idle for another 4 minutes until the schedule invokes it again.

Setting this value to 60000ms (1 minute) means that the lambda will now actually process messages for 4 minutes, then leave a minute for the mesh-download lambda to acknowledge them before starting processing again.

## Validation
<img width="1620" height="790" alt="Screenshot 2026-04-27 at 14 09 45" src="https://github.com/user-attachments/assets/c20a89fb-18de-4a2d-b240-4b04d91012ba" />

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming
<!-- - [ ] If I have used the 'skip-trivy-package' label I have done so responsibly and in the knowledge that this is being fixed as part of a separate ticket/PR. TODO - Re-visit Trivy usage https://nhsd-jira.digital.nhs.uk/browse/CCM-15549 -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
