### PR TITLE
CCM-15276: Update Core Notify Tests for Non Prod

### DIFF
--- a/tests/playwright/config/component/senders.setup.ts
+++ b/tests/playwright/config/component/senders.setup.ts
@@ -2,6 +2,7 @@ import { test as setup } from '@playwright/test';
 import senderRepository from 'helpers/sender-helpers';
 import { Sender } from 'utils';
 import {
+  ROUTING_CONFIG_ID,
   SENDER_ID_SKIPS_NOTIFY,
   SENDER_ID_THAT_TRIGGERS_ERROR_IN_NOTIFY_SANDBOX,
   SENDER_ID_VALID_FOR_NOTIFY_SANDBOX,
@@ -20,7 +21,7 @@ const testSenders: Sender[] = [
     senderName: 'componentTestSender_RoutingConfig',
     meshMailboxSenderId: 'meshMailboxSender1',
     meshMailboxReportsId: 'meshMailboxReports1',
-    routingConfigId: 'b838b13c-f98c-4def-93f0-515d4e4f4ee1',
+    routingConfigId: ROUTING_CONFIG_ID,
     fallbackWaitTimeSeconds: 100,
   },
   {

--- a/tests/playwright/constants/tests-constants.ts
+++ b/tests/playwright/constants/tests-constants.ts
@@ -14,14 +14,16 @@ export const EXISTING_SENDER_IDS = [
 ];
 
 export const ENVIRONMENT_SPECIFIC_CONSTANTS = {
-  // Suppliers Dev Account
+  // Suppliers Dev Account (Sandbox)
   '820178564574': {
     nhsAppBaseUrl: 'https://example.com',
+    routingConfigId: 'b838b13c-f98c-4def-93f0-515d4e4f4ee1',
   },
 
-  // Suppliers Non Prod Account
+  // Suppliers Non Prod Account (Int)
   '885964308133': {
     nhsAppBaseUrl: 'https://www-onboardingaos.nhsapp.service.nhs.uk',
+    routingConfigId: 'c940a9ce-e70d-4986-8046-afd168b39738',
   },
 };
 
@@ -29,3 +31,8 @@ export const NHS_APP_BASE_URL =
   ENVIRONMENT_SPECIFIC_CONSTANTS[
     AWS_ACCOUNT_ID_SAFE as keyof typeof ENVIRONMENT_SPECIFIC_CONSTANTS
   ].nhsAppBaseUrl;
+
+export const ROUTING_CONFIG_ID =
+  ENVIRONMENT_SPECIFIC_CONSTANTS[
+    AWS_ACCOUNT_ID_SAFE as keyof typeof ENVIRONMENT_SPECIFIC_CONSTANTS
+  ].routingConfigId;

--- a/tests/playwright/digital-letters-component-tests/core-notify.component.spec.ts
+++ b/tests/playwright/digital-letters-component-tests/core-notify.component.spec.ts
@@ -76,8 +76,7 @@ test.describe('Digital Letters - Core Notify', () => {
         CORE_NOTIFIER_LAMBDA_LOG_GROUP_NAME,
         [
           '$.message.description  = "Successfully processed request and sent to Notify"',
-          `$.message.messageReference  = "${messageReference}"`,
-          `$.message.senderId  = "${SENDER_ID_VALID_FOR_NOTIFY_SANDBOX}"`,
+          `$.message.messageReference  = "${SENDER_ID_VALID_FOR_NOTIFY_SANDBOX}_${messageReference}"`,
         ],
       );
 

--- a/tests/playwright/digital-letters-component-tests/core-notify.component.spec.ts
+++ b/tests/playwright/digital-letters-component-tests/core-notify.component.spec.ts
@@ -76,7 +76,8 @@ test.describe('Digital Letters - Core Notify', () => {
         CORE_NOTIFIER_LAMBDA_LOG_GROUP_NAME,
         [
           '$.message.description  = "Successfully processed request and sent to Notify"',
-          `$.message.messageReference  = "${SENDER_ID_VALID_FOR_NOTIFY_SANDBOX}_${messageReference}"`,
+          `$.message.messageReference  = "${messageReference}"`,
+          `$.message.senderId  = "${SENDER_ID_VALID_FOR_NOTIFY_SANDBOX}"`,
         ],
       );
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Updated core notify tests to support non-prod routing configurations that exist.

## Context

Allows us to run tests in non-prod without tests falling over.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [X] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming
<!-- - [ ] If I have used the 'skip-trivy-package' label I have done so responsibly and in the knowledge that this is being fixed as part of a separate ticket/PR. TODO - Re-visit Trivy usage https://nhsd-jira.digital.nhs.uk/browse/CCM-15549 -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
