### PR TITLE
CCM-17514: Update CSV Report to use Delivered

### DIFF
--- a/infrastructure/terraform/components/dl/scripts/sql/reports/daily_report.sql
+++ b/infrastructure/terraform/components/dl/scripts/sql/reports/daily_report.sql
@@ -25,7 +25,7 @@ WITH vars AS (
             WHEN e.type LIKE '%.print.invalid.attachment.received.%' THEN 'Failed'
             WHEN e.letterstatus = 'RETURNED' THEN 'Returned'
             WHEN e.letterstatus = 'FAILED' THEN 'Failed'
-            WHEN e.letterstatus = 'DISPATCHED' THEN 'Dispatched'
+            WHEN e.letterstatus = 'DELIVERED' THEN 'Delivered'
             WHEN e.letterstatus = 'REJECTED' THEN 'Rejected' ELSE NULL
         END as status,
         e.reasoncode,
@@ -55,7 +55,7 @@ WITH vars AS (
                     -- Print Priority Order
                     WHEN te.status = 'Returned' THEN 4
                     WHEN te.communicationtype = 'Print' AND te.status = 'Failed' THEN 3
-                    WHEN te.status = 'Dispatched' THEN 2
+                    WHEN te.status = 'Delivered' THEN 2
                     WHEN te.status = 'Rejected' THEN 1 ELSE 0
                 END DESC
         ) AS "row_number",

--- a/tests/playwright/digital-letters-component-tests/report-generator.component.spec.ts
+++ b/tests/playwright/digital-letters-component-tests/report-generator.component.spec.ts
@@ -108,10 +108,10 @@ const scenarios = [
     'The letter was returned',
   ),
   new ReportScenario(
-    'component-test-dispatched',
+    'component-test-delivered',
     CommunicationType.Print,
-    [EventStatus.Dispatched],
-    'Dispatched',
+    [EventStatus.Delivered],
+    'Delivered',
     senderId,
   ),
   // Scenario for new Print failure event: FileQuarantined
@@ -134,7 +134,7 @@ const scenarios = [
     'DL_CLIV_002',
     'Invalid attachment received',
   ),
-  // multiple events for the same message reference, should take the one with highest priority status (returned > failed > dispatched > rejected)
+  // multiple events for the same message reference, should take the one with highest priority status (returned > failed > delivered > rejected)
   new ReportScenario(
     'component-test-rejected-pending',
     CommunicationType.Print,
@@ -145,27 +145,27 @@ const scenarios = [
     'The letter was rejected.',
   ), // pending is ignored.
   new ReportScenario(
-    'component-test-rejected-dispatched',
+    'component-test-rejected-delivered',
     CommunicationType.Print,
-    [EventStatus.Rejected, EventStatus.Dispatched],
-    'Dispatched',
+    [EventStatus.Rejected, EventStatus.Delivered],
+    'Delivered',
     senderId,
   ),
   new ReportScenario(
-    'component-test-rejected-dispatched-failed',
+    'component-test-rejected-delivered-failed',
     CommunicationType.Print,
-    [EventStatus.Rejected, EventStatus.Dispatched, EventStatus.Failed],
+    [EventStatus.Rejected, EventStatus.Delivered, EventStatus.Failed],
     'Failed',
     senderId,
     'API_CODE_002',
     'Letter processing failed',
   ),
   new ReportScenario(
-    'component-test-rejected-dispatched-failed-returned',
+    'component-test-rejected-delivered-failed-returned',
     CommunicationType.Print,
     [
       EventStatus.Rejected,
-      EventStatus.Dispatched,
+      EventStatus.Delivered,
       EventStatus.Failed,
       EventStatus.Returned,
     ],

--- a/tests/playwright/helpers/report-helpers.ts
+++ b/tests/playwright/helpers/report-helpers.ts
@@ -63,6 +63,7 @@ export enum EventStatus {
   Rejected = 'REJECTED',
   Printed = 'PRINTED',
   Dispatched = 'DISPATCHED',
+  Delivered = 'DELIVERED',
   Failed = 'FAILED',
   Returned = 'RETURNED',
   Pending = 'PENDING',


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Changes the CSV report and component tests to use DELIVERED instead of DISPATCHED.

## Context

So we more accurately know the status of the letter.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [X] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming
<!-- - [ ] If I have used the 'skip-trivy-package' label I have done so responsibly and in the knowledge that this is being fixed as part of a separate ticket/PR. TODO - Re-visit Trivy usage https://nhsd-jira.digital.nhs.uk/browse/CCM-15549 -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.

Evidence from the component test runs:
 https://github.com/NHSDigital/nhs-notify-internal/actions/runs/25371494642/job/74396367666
<img width="1198" height="460" alt="image" src="https://github.com/user-attachments/assets/75741251-eaee-4404-9799-8026f00456ba" />
